### PR TITLE
fix svg files missing when doing build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -461,6 +461,12 @@ module.exports = function (grunt, options) {
           ]
         }]
       },
+      svg: {
+        expand: true,
+        cwd: 'app/images',
+        src: '{,*/}*.svg',
+        dest: 'dist/images'
+      },
       styles: {
         expand: true,
         cwd: 'app/styles',
@@ -496,6 +502,7 @@ module.exports = function (grunt, options) {
       dist: [
         'imagemin',
         //'svgmin',
+        'copy:svg',
         'copy:dist'
       ]
     },


### PR DESCRIPTION
The previous [commit](https://github.com/wix/wix-gruntfile/commit/d2d715ffa5b16724f163419c5fcbdc67c0c04e5a) stopped including svg files at all (in an effort to fix svgmin being faulty, presumably).
