### PR TITLE
run FF on Win7

### DIFF
--- a/protractor-teamcity-conf.js
+++ b/protractor-teamcity-conf.js
@@ -22,7 +22,7 @@ var sauceLabsBrowsers = {
   },
   FF: {
     browserName: 'firefox',
-    platform: 'Windows 8'
+    platform: 'Windows 7'
   },
   IE11: {
     browserName: 'internet explorer',


### PR DESCRIPTION
Integration tests are failing in FF on Win8. It seems a known issue in FF and Win8. The change of flag doesn't solve the problem. Ive sent the issue to Sauce Labs as well.
https://support.mozilla.org/en-US/questions/986902
