### PR TITLE
Increase max instances of Sauce Labs VMs following plan upgrade

### DIFF
--- a/protractor-teamcity-conf.js
+++ b/protractor-teamcity-conf.js
@@ -60,7 +60,7 @@ config.multiCapabilities = testBrowsers.map(function (key) {
   browser['screen-resolution'] = '1280x1024';
   browser.build = process.env.BUILD_NUMBER;
   browser.shardTestFiles = true;
-  browser.maxInstances = 3;
+  browser.maxInstances = 10;
   return sauceLabsBrowsers[key];
 });
 


### PR DESCRIPTION
I set 10, but I'm not sure we should be using this amount.

On the one hand, 10 is 3 times for than what we have now and we should see improvements in CI tests times. Also, this will allow multiple CI projects to run in parallel without waiting for the other project to finish first.
On the other hand, we have 15 VMs and we will not be utilizing all of them. There might be cases where there are no other projects testing in the same time and we still do not use all of our capacity. This seems like a little bit of a waste.

WDYT?
