### PR TITLE
feat(replace): register replace task as a more specific task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -160,11 +160,11 @@ module.exports = function (grunt, options) {
       },
       replace: {
         files: ['app/**/*.vm'],
-        tasks: ['replace', 'copy:vm']
+        tasks: ['replace:dist', 'copy:vm']
       },
       replaceConf: {
         files: ['replace.conf.js', 'replace.private.conf.js'],
-        tasks: ['replace', 'copy:vm'],
+        tasks: ['replace:dist', 'copy:vm'],
         options: {reload: true}
       },
       locale: {
@@ -640,7 +640,7 @@ module.exports = function (grunt, options) {
       server: [
         'haml',
         'compass:dist',
-        'replace',
+        'replace:dist',
         'copy:styles',
         'jsonAngularTranslate'
       ],


### PR DESCRIPTION
replace object has only one key:
    replace: {
      dist: {
        src: ['app/*.vm'],
        dest: '.tmp/',
        replacements: loadReplacements()
      }
    },

The purpose of this fix is to make the replace command more specific. 

This will enable me to add more replace commands and register them without colliding with replace:dist command (it is required in the wix-styles project)
