### PR TITLE
Add the ability to concatenate locale files

### DIFF
--- a/grunt-sections/minify.js
+++ b/grunt-sections/minify.js
@@ -37,6 +37,11 @@ module.exports = function (grunt, options) {
           cwd: 'dist/concat',
           src: '**/*.js',
           dest: 'dist/concat'
+        }, {
+          expand: true,
+          cwd: 'dist/scripts',
+          src: '**/locale/**/*.js',
+          dest: 'dist/scripts'
         }]
       }
     },

--- a/grunt-sections/minify.js
+++ b/grunt-sections/minify.js
@@ -37,11 +37,6 @@ module.exports = function (grunt, options) {
           cwd: 'dist/concat',
           src: '**/*.js',
           dest: 'dist/concat'
-        }, {
-          expand: true,
-          cwd: 'dist/scripts',
-          src: '**/locale/**/*.js',
-          dest: 'dist/scripts'
         }]
       }
     },


### PR DESCRIPTION
Fixes https://jira.wixpress.com/browse/NGG-32

Uses ${locale} to determine pattern, we can change it to something else, but I think the flexibility is quite nice.