### PR TITLE
feat(webfont): font name will not be generated with random number

### DIFF
--- a/grunt-sections/generators.js
+++ b/grunt-sections/generators.js
@@ -47,6 +47,7 @@ module.exports = function (grunt, options) {
           htmlDemo: false,
           stylesheet: 'scss',
           engine: 'node',
+          hashes: false,
           font: options.svgFontName + '-svg-font-icons',
           template: path.join(__dirname, '../webfont-css-generator-template.css'), /* Custom template is a copy-paste of 'bootstrap' template + including 'bem' general class so it will be easily used with @mixins */
           templateOptions: {


### PR DESCRIPTION
They keep changing every time 'grunt build' is executed and that is annoying We don't need version control for webfonts