### PR TITLE
Adding "chromeHeadless" browser type, for use with Traceur

### DIFF
--- a/grunt-sections/test-runners.js
+++ b/grunt-sections/test-runners.js
@@ -51,6 +51,11 @@ module.exports = function (grunt, options) {
         ngHtml2JsPreprocessor: {
           stripPrefix: '(app|.tmp)/',
           moduleName: options.preloadModule
+        },
+        customLaunchers: {
+          chromeHeadless: {
+            base: 'Chrome'
+          }
         }
       },
       teamcity: {
@@ -58,7 +63,14 @@ module.exports = function (grunt, options) {
           configFile: path.join(__dirname, '../karma.conf.js'),
           files: options.unitTestFiles,
           reporters: ['teamcity', 'coverage'],
-          coverageReporter: { type: 'teamcity' }
+          coverageReporter: { type: 'teamcity' },
+          customLaunchers: {
+            chromeHeadless: {
+              base: 'Chrome',
+              // required to run Chrome in a headless server (Xvfb)
+              flags: ['--no-sandbox']
+            }
+          }
         }
       },
       single: {

--- a/grunt-sections/test-runners.js
+++ b/grunt-sections/test-runners.js
@@ -51,11 +51,6 @@ module.exports = function (grunt, options) {
         ngHtml2JsPreprocessor: {
           stripPrefix: '(app|.tmp)/',
           moduleName: options.preloadModule
-        },
-        customLaunchers: {
-          chromeHeadless: {
-            base: 'Chrome'
-          }
         }
       },
       teamcity: {
@@ -63,14 +58,8 @@ module.exports = function (grunt, options) {
           configFile: path.join(__dirname, '../karma.conf.js'),
           files: options.unitTestFiles,
           reporters: ['teamcity', 'coverage'],
-          coverageReporter: { type: 'teamcity' },
-          customLaunchers: {
-            chromeHeadless: {
-              base: 'Chrome',
-              // required to run Chrome in a headless server (Xvfb)
-              flags: ['--no-sandbox']
-            }
-          }
+          coverageReporter: { type: 'teamcity' }
+
         }
       },
       single: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -59,12 +59,23 @@ module.exports = function (config) {
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
+    // - chromeHeadless (will start in headless mode in TeamCity)
     // - Firefox
     // - Opera
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: featureDetector.isTraceurEnabled() ? ['Chrome'] : ['PhantomJS'],
+    browsers: featureDetector.isTraceurEnabled() ? ['chromeHeadless'] : ['PhantomJS'],
+
+    // browser configuration
+    customLaunchers: {
+      chromeNoSandbox: {
+        base: 'Chrome',
+
+        // required to run Chrome in a headless server (Xvfb)
+        flags: ['--no-sandbox']
+      }
+    },
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,16 +67,6 @@ module.exports = function (config) {
     // - IE (only Windows)
     browsers: featureDetector.isTraceurEnabled() ? ['chromeHeadless'] : ['PhantomJS'],
 
-    // browser configuration
-    customLaunchers: {
-      chromeNoSandbox: {
-        base: 'Chrome',
-
-        // required to run Chrome in a headless server (Xvfb)
-        flags: ['--no-sandbox']
-      }
-    },
-
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
     singleRun: true

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -59,13 +59,22 @@ module.exports = function (config) {
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
-    // - chromeHeadless (will start in headless mode in TeamCity)
+    // - chromeHeadless (will start in "headless" mode)
     // - Firefox
     // - Opera
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
     browsers: featureDetector.isTraceurEnabled() ? ['chromeHeadless'] : ['PhantomJS'],
+
+    // browser configuration
+    customLaunchers: {
+      chromeHeadless: {
+        base: 'Chrome',
+        // required to run Chrome in a headless environment (Xvfb)
+        flags: ['--no-sandbox']
+      }
+    },
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit


### PR DESCRIPTION
This change is required for builds that use Traceur.
Traceur generates code which fails to run in PhantomJS, therefore Chrome is used instead.
To run Chrome in TeamCity it needs to be started with a --no-sandbox flag, otherwise it fails to start, resulting in the following error:

```
Running "karma:teamcity" (karma) task
[12:13:34][Step 5/9] INFO [karma]: Karma v0.12.31 server started at http://localhost:8880/
[12:13:34][Step 5/9] INFO [launcher]: Starting browser Chrome
[12:13:34][Step 5/9] WARN [watcher]: Pattern "/home/builduser/agent08/work/ea12f074042b08d0/{app,.tmp}/*.js" does not match any file.
[12:14:34][Step 5/9] WARN [launcher]: Chrome have not captured in 60000 ms, killing.
[12:14:34][Step 5/9] INFO [launcher]: Trying to start Chrome again (1/2).
[12:15:34][Step 5/9] WARN [launcher]: Chrome have not captured in 60000 ms, killing.
[12:15:34][Step 5/9] INFO [launcher]: Trying to start Chrome again (2/2).
[12:16:34][Step 5/9] WARN [launcher]: Chrome have not captured in 60000 ms, killing.
[12:16:34][Step 5/9] ERROR [launcher]: Chrome failed 2 times (timeout). Giving up.
[12:16:34][Step 5/9] Warning: Task "karma:teamcity" failed. Use --force to continue.
```
