### PR TITLE
Add font declaration before wix style fonts params.

### DIFF
--- a/grunt-sections/build-html.js
+++ b/grunt-sections/build-html.js
@@ -172,7 +172,7 @@ module.exports = function (grunt, options) {
           },
           postProcess: function (css) {
             // wix tpa params uses {{}}, convert back the [[]] to {{}}.
-            var ret = css.replace(/font: \[\[([^\]]+)\]\];/g, '{{$1}};');
+            var ret = css.replace(/font: \[\[([^\]]+)\]\];/g, 'font:;{{$1}};');
             ret = ret.replace(/\[\[([^\]}]+)\]\]/g, '{{$1}}');
             return ret;
           },


### PR DESCRIPTION
SDK can't handle something like that:
```css
.button {{{BODY-M}}}
```
This is the result of minification.

This is the [Regex](https://github.com/wix/js-sdk/blob/0343d1f848f9edaa84854c56071b31738bc22f24/src/main/static/js/modules/privates/core.js#L181) used.