### PR TITLE
dont run process tags on bower components

### DIFF
--- a/grunt-sections/build-html.js
+++ b/grunt-sections/build-html.js
@@ -147,7 +147,7 @@ module.exports = function (grunt, options) {
         files: [{
           expand: true,
           cwd: 'dist',
-          src: '**/*.{html,vm}',
+          src: '**{!bower_components}/*.{html,vm}',
           dest: 'dist'
         }]
       }


### PR DESCRIPTION
When working with bower link, process tags fails.