### PR TITLE
use grunt-newer on jshint, jscs and tslint tasks

### DIFF
--- a/grunt-sections/codestyle.js
+++ b/grunt-sections/codestyle.js
@@ -17,16 +17,16 @@ module.exports = function (grunt) {
 
   grunt.registerTask('jsstyleIfEnabled', function () {
     if (featureDetector.isJshintEnabled()) {
-      grunt.task.run('jshint');
+      grunt.task.run('newer:jshint');
     }
     if (featureDetector.isJscsEnabled()) {
-      grunt.task.run('jscs');
+      grunt.task.run('newer:jscs');
     }
     if (featureDetector.isTslintEnabled()) {
       var config = grunt.config('tslint');
       config.options.configuration = grunt.file.readJSON('tslint.json');
       grunt.config('tslint', config);
-      grunt.task.run('tslint');
+      grunt.task.run('newer:tslint');
     }
   });
 
@@ -40,14 +40,14 @@ module.exports = function (grunt) {
     tslint: {
       options: {
       },
-      files: {
+      files: [{
         src: [
           'app/{scripts,modules}/**/*.ts',
           'test/{spec,mock,e2e}/**/*.ts',
           '!app/scripts/typings/**/*.ts',
           '!app/scripts/reference.ts'
         ]
-      }
+      }]
     },
     jshint: {
       options: {
@@ -58,36 +58,36 @@ module.exports = function (grunt) {
         options: {
           jshintrc: '.jshintrc'
         },
-        files: {
+        files: [{
           src: [
             'Gruntfile.js',
             'app/{scripts,modules}/**/*.js',
             '!app/modules/**/*.test.js',
             '!app/scripts/lib/**/*.js'
           ]
-        }
+        }]
       },
       test: {
         options: {
           jshintrc: 'test/.jshintrc'
         },
-        files: {
+        files: [{
           src: ['test/{spec,mock,e2e}/**/*.js', 'app/modules/**/*.test.js']
-        }
+        }]
       }
     },
     jscs: {
       options: {
         config: '.jscsrc'
       },
-      files: {
+      files: [{
         src: [
           'Gruntfile.js',
           'app/{scripts,modules}/**/*.js',
           '!app/scripts/lib/**/*.js',
           'test/{spec,mock,e2e}/**/*.js'
         ]
-      }
+      }]
     },
     scsslint: {
       styles: [

--- a/grunt-sections/codestyle.js
+++ b/grunt-sections/codestyle.js
@@ -80,14 +80,16 @@ module.exports = function (grunt) {
       options: {
         config: '.jscsrc'
       },
-      files: [{
-        src: [
-          'Gruntfile.js',
-          'app/{scripts,modules}/**/*.js',
-          '!app/scripts/lib/**/*.js',
-          'test/{spec,mock,e2e}/**/*.js'
-        ]
-      }]
+      all: {
+        files: [{
+          src: [
+            'Gruntfile.js',
+            'app/{scripts,modules}/**/*.js',
+            '!app/scripts/lib/**/*.js',
+            'test/{spec,mock,e2e}/**/*.js'
+          ]
+        }]
+      }
     },
     scsslint: {
       styles: [

--- a/grunt-sections/codestyle.js
+++ b/grunt-sections/codestyle.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
       var config = grunt.config('tslint');
       config.options.configuration = grunt.file.readJSON('tslint.json');
       grunt.config('tslint', config);
-      grunt.task.run('newer:tslint');
+      grunt.task.run('tslint');
     }
   });
 
@@ -40,14 +40,14 @@ module.exports = function (grunt) {
     tslint: {
       options: {
       },
-      files: [{
+      files: {
         src: [
           'app/{scripts,modules}/**/*.ts',
           'test/{spec,mock,e2e}/**/*.ts',
           '!app/scripts/typings/**/*.ts',
           '!app/scripts/reference.ts'
         ]
-      }]
+      }
     },
     jshint: {
       options: {


### PR DESCRIPTION
It is not sufficient to only prefix 'newer:', because
this path would be taken by grunt:
https://github.com/gruntjs/grunt/blob/e6f9cdfd61e35f8dc81649c544b8645621ab103d/lib/grunt/task.js#L107
Which results in grunt-newer seeing set 'dest' as directory 'src' and
, as is documented in it's readme, passing all the files to the style checker.

Thus, we choose to take this path
https://github.com/gruntjs/grunt/blob/e6f9cdfd61e35f8dc81649c544b8645621ab103d/lib/grunt/task.js#L110
Which results in the original objects with only 'src' property and no
'dest' be preserved and the grunt-newer check would behave as expected.