### PR TITLE
use grunt-newer on jshint and jscs tasks

### DIFF
--- a/grunt-sections/codestyle.js
+++ b/grunt-sections/codestyle.js
@@ -17,10 +17,10 @@ module.exports = function (grunt) {
 
   grunt.registerTask('jsstyleIfEnabled', function () {
     if (featureDetector.isJshintEnabled()) {
-      grunt.task.run('jshint');
+      grunt.task.run('newer:jshint');
     }
     if (featureDetector.isJscsEnabled()) {
-      grunt.task.run('jscs');
+      grunt.task.run('newer:jscs');
     }
     if (featureDetector.isTslintEnabled()) {
       var config = grunt.config('tslint');
@@ -58,35 +58,37 @@ module.exports = function (grunt) {
         options: {
           jshintrc: '.jshintrc'
         },
-        files: {
+        files: [{
           src: [
             'Gruntfile.js',
             'app/{scripts,modules}/**/*.js',
             '!app/modules/**/*.test.js',
             '!app/scripts/lib/**/*.js'
           ]
-        }
+        }]
       },
       test: {
         options: {
           jshintrc: 'test/.jshintrc'
         },
-        files: {
+        files: [{
           src: ['test/{spec,mock,e2e}/**/*.js', 'app/modules/**/*.test.js']
-        }
+        }]
       }
     },
     jscs: {
       options: {
         config: '.jscsrc'
       },
-      files: {
-        src: [
-          'Gruntfile.js',
-          'app/{scripts,modules}/**/*.js',
-          '!app/scripts/lib/**/*.js',
-          'test/{spec,mock,e2e}/**/*.js'
-        ]
+      all: {
+        files: [{
+          src: [
+            'Gruntfile.js',
+            'app/{scripts,modules}/**/*.js',
+            '!app/scripts/lib/**/*.js',
+            'test/{spec,mock,e2e}/**/*.js'
+          ]
+        }]
       }
     },
     scsslint: {


### PR DESCRIPTION
It is not sufficient to only prefix 'newer:', because
this path would be taken by grunt:
https://github.com/gruntjs/grunt/blob/e6f9cdfd61e35f8dc81649c544b8645621ab103d/lib/grunt/task.js#L107
Which results in grunt-newer seeing set 'dest' as directory 'src' and
, as is documented in it's readme, passing all the files to the style checker.

Thus, we choose to take this path
https://github.com/gruntjs/grunt/blob/e6f9cdfd61e35f8dc81649c544b8645621ab103d/lib/grunt/task.js#L110
Which results in the original objects with only 'src' property and no
'dest' be preserved and the grunt-newer check would behave as expected.