### PR TITLE
Removing an un needed parameter from uglify options regarding sourceMap.

### DIFF
--- a/grunt-sections/minify.js
+++ b/grunt-sections/minify.js
@@ -45,8 +45,7 @@ module.exports = function (grunt, options) {
         mangle: !options.bowerComponent,
         compress: options.bowerComponent ? false : {},
         beautify: options.bowerComponent,
-        sourceMap: true,
-        sourceMapIncludeSources: true
+        sourceMap: true
       },
       locale: {
         files: [{


### PR DESCRIPTION
Removing an un needed parameter from the sourceMap, from now on sourceMaps will be able to point to a file in a different directory.