### PR TITLE
Added coverage support for modules projects structure.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,7 @@ module.exports = function (config) {
 
     preprocessors: {
       '{app,.tmp}/scripts/{,!(lib)/**/}*.js': 'coverage',
+      '{app,.tmp}/modules/{,/**/}!(*.test).js': 'coverage',
       '{app,.tmp}/**/*.html': 'ng-html2js',
       '{app,.tmp}/images/**/*.svg': 'ng-html2js'
     },


### PR DESCRIPTION
I tried to use modular project structure inside the ShoutOuts project.
And was missing the coverage report for the code inside the ./app/modules/.

I have added exclusion patter !(*.test).js, because i don't the tests to be instrumented.