### PR TITLE
grunt.hookTask: rename config along with original task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -245,10 +245,13 @@ module.exports = function (grunt, options) {
   });
 
   grunt.hookTask = function (name) {
-    var hooked = name + '.hooked.' + Math.floor(Math.random() * 10000);
+    var hooked = name + '(hooked' + Math.floor(Math.random() * 10000) + ')';
     var arr = [hooked];
     grunt.renameTask(name, hooked);
     grunt.registerTask(name, arr);
+    var hookedCfgPath = hooked.replace(/:/g, '.');
+    var nameCfgPath = name.replace(/:/g, '.');
+    grunt.config.set(hookedCfgPath, grunt.config.get(nameCfgPath));
     return arr;
   };
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -251,7 +251,7 @@ module.exports = function (grunt, options) {
     grunt.registerTask(name, arr);
     var hookedCfgPath = hooked.replace(/:/g, '.');
     var nameCfgPath = name.replace(/:/g, '.');
-    grunt.config.set(hookedCfgPath, grunt.config.get(nameCfgPath));
+    grunt.config.set(hookedCfgPath, grunt.config.getRaw(nameCfgPath));
     return arr;
   };
 


### PR DESCRIPTION
Had to replace the dots in the name with parenthesis, because the grunt config function would get confused.