### PR TITLE
feat(Grunt Protractor): allow running two parallel test:ci processes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -239,6 +239,26 @@ module.exports = function (grunt, options) {
     'e2eIfEnabled:teamcity'
   ]);
 
+  grunt.registerTask('test:ci_parallel_main_server', [
+    'e2eIfEnabled:teamcity_main_server_parallel'
+  ]);
+
+  grunt.registerTask('test:ci_parallel_diff_server_diff_tunnel', [
+    'e2eIfEnabled:teamcity_diff_server_diff_tunnel'
+  ]);
+
+  grunt.registerTask('test:ci_parallel_same_tunnel', [
+    'e2eIfEnabled:teamcity_diff_server_diff_tunnel'
+  ]);
+
+  grunt.registerTask('test:ci_parallel_same_server', [
+    'e2eIfEnabled:teamcity_same_server'
+  ]);
+
+  grunt.registerTask('test:ci_parallel_same_server_tunnel', [
+    'e2eIfEnabled:teamcity_same_server_tunnel'
+  ]);
+
   grunt.registerTask('build', [
     'pre-build:clean',
     'karma:single',

--- a/grunt-sections/connect.js
+++ b/grunt-sections/connect.js
@@ -42,6 +42,18 @@ module.exports = function (grunt, options) {
     return connect.static(require('path').resolve(grunt.template.process(dir)), { maxAge: maxage || 0 });
   }
 
+  function middlewareServerBuildWithCache(connect) {
+    return getProxies('beforeProxies').concat([
+      //connect.compress(),
+      connect.favicon(),
+      mountFolder(connect, 'test', 86400000),
+      mountFolder(connect, 'dist', 86400000),
+      connect.urlencoded()
+    ]).concat(grunt.config('yeoman').e2eTestServer ?
+        [proxyFolder('/_api/', '<%= yeoman.e2eTestServer %>')] : [])
+        .concat(getProxies('proxies'));
+  }
+
   return {
     options: {
       port: options.port,
@@ -90,17 +102,13 @@ module.exports = function (grunt, options) {
     test: {
       options: {
         port: 9876,
-        middleware: function (connect) {
-          return getProxies('beforeProxies').concat([
-            //connect.compress(),
-            connect.favicon(),
-            mountFolder(connect, 'test', 86400000),
-            mountFolder(connect, 'dist', 86400000),
-            connect.urlencoded()
-          ]).concat(grunt.config('yeoman').e2eTestServer ?
-              [proxyFolder('/_api/', '<%= yeoman.e2eTestServer %>')] : [])
-            .concat(getProxies('proxies'));
-        }
+        middleware: middlewareServerBuildWithCache
+      }
+    },
+    testSecondaryServer: {
+      options: {
+        port: 9877,
+        middleware: middlewareServerBuildWithCache
       }
     },
     dist: {

--- a/grunt-sections/test-runners.js
+++ b/grunt-sections/test-runners.js
@@ -47,6 +47,41 @@ module.exports = function (grunt, options) {
     }
   });
 
+  grunt.registerTask('e2eIfEnabled:teamcity_main_server_parallel', function () {
+    if (options.protractor) {
+      grunt.task.run('connect:test');
+      grunt.task.run('protractor:teamcity_main_server_parallel');
+    }
+  });
+
+  grunt.registerTask('e2eIfEnabled:teamcity_diff_server_diff_tunnel', function () {
+    if (options.protractor) {
+      grunt.task.run('connect:testSecondaryServer');
+      grunt.task.run('protractor:teamcity_diff_server_diff_tunnel');
+    }
+  });
+
+  grunt.registerTask('e2eIfEnabled:teamcity_same_server_tunnel', function () {
+    if (options.protractor) {
+      grunt.task.run('connect:testSecondaryServer');
+      grunt.task.run('protractor:teamcity_same_server_tunnel');
+    }
+  });
+
+  grunt.registerTask('e2eIfEnabled:teamcity_same_server', function () {
+    if (options.protractor) {
+      grunt.task.run('connect:testSecondaryServer');
+      grunt.task.run('protractor:teamcity_same_server');
+    }
+  });
+
+  grunt.registerTask('e2eIfEnabled:teamcity_same_tunnel', function () {
+    if (options.protractor) {
+      grunt.task.run('connect:testSecondaryServer');
+      grunt.task.run('protractor:teamcity_same_tunnel');
+    }
+  });
+
   return {
     karma: {
       options: {
@@ -93,7 +128,43 @@ module.exports = function (grunt, options) {
       teamcity: {
         options: {
           configFile: path.join(__dirname, '../protractor-teamcity-conf.js'),
-          baseUrl: 'http://localhost:9876/'
+          baseUrl: 'http://localhost:9876/',
+          sauceSeleniumAddress: 'localhost:4445/wd/hub'
+        }
+      },
+      teamcity_main_server_parallel: {
+        options: {
+          configFile: path.join(__dirname, '../protractor-teamcity-conf-part1-tunnel1.js'),
+          baseUrl: 'http://localhost:9876/',
+          sauceSeleniumAddress: 'localhost:4445/wd/hub'
+        }
+      },
+      teamcity_diff_server_diff_tunnel: {
+        options: {
+          configFile: path.join(__dirname, '../protractor-teamcity-conf-part2-tunnel2.js'),
+          baseUrl: 'http://localhost:9877/',
+          sauceSeleniumAddress: 'localhost:4446/wd/hub'
+        }
+      },
+      teamcity_same_server_tunnel: {
+        options: {
+          configFile: path.join(__dirname, '../protractor-teamcity-conf-part2-tunnel1.js'),
+          baseUrl: 'http://localhost:9876/',
+          sauceSeleniumAddress: 'localhost:4445/wd/hub'
+        }
+      },
+      teamcity_same_tunnel: {
+        options: {
+          configFile: path.join(__dirname, '../protractor-teamcity-conf-part2-tunnel1.js'),
+          baseUrl: 'http://localhost:9877/',
+          sauceSeleniumAddress: 'localhost:4445/wd/hub'
+        }
+      },
+      teamcity_same_server: {
+        options: {
+          configFile: path.join(__dirname, '../protractor-teamcity-conf-part2-tunnel2.js'),
+          baseUrl: 'http://localhost:9876/',
+          sauceSeleniumAddress: 'localhost:4446/wd/hub'
         }
       }
     }

--- a/protractor-teamcity-conf-part1-tunnel1.js
+++ b/protractor-teamcity-conf-part1-tunnel1.js
@@ -1,0 +1,10 @@
+/* global process, exports, jasmine */
+'use strict';
+
+var config = require('./protractor-teamcity-conf').config;
+var arrays = require('./protractor-teamcity-conf').arrays;
+
+
+config.multiCapabilities = arrays.cap1;
+
+exports.config = config;

--- a/protractor-teamcity-conf-part2-tunnel1.js
+++ b/protractor-teamcity-conf-part2-tunnel1.js
@@ -1,0 +1,10 @@
+/* global process, exports, jasmine */
+'use strict';
+
+var config = require('./protractor-teamcity-conf').config;
+var arrays = require('./protractor-teamcity-conf').arrays;
+
+
+config.multiCapabilities = arrays.cap2;
+
+exports.config = config;

--- a/protractor-teamcity-conf-part2-tunnel2.js
+++ b/protractor-teamcity-conf-part2-tunnel2.js
@@ -1,0 +1,14 @@
+/* global process, exports, jasmine */
+'use strict';
+
+var config = require('./protractor-teamcity-conf').config;
+var arrays = require('./protractor-teamcity-conf').arrays;
+
+for (var i = 0 ; i < arrays.cap2.length ; i++) {
+    var browser = arrays.cap2[i];
+    browser['tunnel-identifier'] = process.env.BUILD_NUMBER + '2';
+}
+
+config.multiCapabilities = arrays.cap2;
+
+exports.config = config;

--- a/protractor-teamcity-conf.js
+++ b/protractor-teamcity-conf.js
@@ -71,9 +71,9 @@ var sauceLabsBrowsers = {
 };
 
 var testBrowsers = (process.env.SAUCE_BROWSERS ? process.env.SAUCE_BROWSERS.split(' ') : Object.keys(sauceLabsBrowsers));
-var shardsLeft = 15;
+var shardsLeft = 16;
 
-config.multiCapabilities = testBrowsers.map(function (key, index) {
+var capabilities = testBrowsers.map(function (key, index) {
   var browser = sauceLabsBrowsers[key];
   browser.name = buildName;
   browser['tunnel-identifier'] = process.env.BUILD_NUMBER;
@@ -88,4 +88,11 @@ config.multiCapabilities = testBrowsers.map(function (key, index) {
   return sauceLabsBrowsers[key];
 });
 
+var indexArr = Math.floor(capabilities.length / 2);
+var capabilities1 = capabilities.slice(0, indexArr);
+var capabilities2 = capabilities.slice(indexArr);
+
+config.multiCapabilities = capabilities;
+
 exports.config = config;
+exports.arrays = {cap1: capabilities1, cap2: capabilities2};

--- a/scripts/parallel_ci.sh
+++ b/scripts/parallel_ci.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -e
+
+CONNECT_URL="https://saucelabs.com/downloads/sc-4.3.9-linux.tar.gz"
+CONNECT_DOWNLOAD="sc-4.3.9-linux"
+CONNECT_DOWNLOAD_FILE=$CONNECT_DOWNLOAD.tar.gz
+CONNECT_DIR=".sauce-connect"
+CONNECT_LOG="log"
+BUILD_REMOTE_LOG="https://build-logs.firebaseio.com/builds.json"
+GRUNT="$NODE_HOME/node node_modules/grunt-cli/bin/grunt"
+SC_EXE="./sc"
+
+NORM=""
+TEXTCOLOR=""
+
+#build_number, port
+function startTunnel {
+	echo "Starting Sauce Connect in the background (tunnel $1)"
+	echo "Logging into $CONNECT_LOG"
+	$SC_EXE --readyfile ./sauce-connect-ready \
+	    --tunnel-identifier $1 \
+	    --user $SAUCE_USERNAME \
+	    --api-key $SAUCE_ACCESS_KEY \
+	    --logfile $CONNECT_LOG \
+	    --se-port $2 \
+	    --tunnel-domains localhost &
+
+}
+
+function startOneTunnel {
+
+	startTunnel $BUILD_NUMBER 4445
+
+    while [ ! -f ./sauce-connect-ready ]; do
+	  echo "Waiting for Sauce Labs..."
+	  sleep 5
+	done
+
+	cd ..
+
+}
+
+function startTwoTunnels {
+
+	SECOND_BUILD_NUMBER="$BUILD_NUMBER""2"
+
+	startTunnel $BUILD_NUMBER 4445
+	startTunnel $SECOND_BUILD_NUMBER 4446
+
+	while [ ! -f ./sauce-connect-ready ] && [ ! -f ./sauce-connect-ready-2 ]; do
+	  echo "Waiting for Sauce Labs..."
+	  sleep 5
+	done
+
+	cd ..
+
+}
+
+# start_time, elapsed time
+function printCompleteCommand {
+	END_DATE=$(date '+%x_%H:%M:%S:%N')
+	curl -X POST -d '{"startTime": "'"$1"'", "endTime": "'"$END_DATE"'", "buildName": "scheduler-client", "buildMode": "'"$BUILD_MODE"'", "totalDuration": "'"$(($2/60)) min $(($2%60)) sec"'"}' $BUILD_REMOTE_LOG
+}
+
+function regular_mode {
+	# regular mode
+	startOneTunnel
+
+	START_DATE=$(date '+%x_%H:%M:%S:%N')
+	START_TIME=$SECONDS
+	$GRUNT test:ci
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "${TEXTCOLOR}***** Done 1: regular mode:${NORM}"
+	echo "${TEXTCOLOR}$(($ELAPSED_TIME/60)) min $(($ELAPSED_TIME%60)) sec ${NORM}"
+	printCompleteCommand $START_DATE $ELAPSED_TIME
+}
+
+function seperate_server_and_tunnel {
+	# two processes on separate tunnel and server
+	startTwoTunnels
+
+	START_DATE=$(date '+%x_%H:%M:%S:%N')
+	START_TIME=$SECONDS
+	$GRUNT test:ci_parallel_main_server & pid1=$!
+	$GRUNT test:ci_parallel_diff_server_diff_tunnel & pid2=$!
+	wait $pid1
+	wait $pid2
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "${TEXTCOLOR}Done 2: separate server and tunnel${NORM}"
+	echo "${TEXTCOLOR}$(($ELAPSED_TIME/60)) min $(($ELAPSED_TIME%60)) sec ${NORM}"
+	printCompleteCommand $START_DATE $ELAPSED_TIME
+}
+
+function same_server_and_tunnel {
+	# two processes on same tunnel and server
+	startOneTunnel
+
+	START_DATE=$(date '+%x_%H:%M:%S:%N')
+	START_TIME=$SECONDS
+	$GRUNT test:ci_parallel_main_server & pid1=$!
+	$GRUNT test:ci_parallel_same_server_tunnel & pid2=$!
+	wait $pid1
+	wait $pid2
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "${TEXTCOLOR}***** Done 3: same server and tunnel${NORM}"
+	echo "${TEXTCOLOR}$(($ELAPSED_TIME/60)) min $(($ELAPSED_TIME%60)) sec ${NORM}"
+	printCompleteCommand $START_DATE $ELAPSED_TIME
+}
+
+function seperate_server_same_tunnel {
+	# two processes on same tunnel and separate server
+	startOneTunnel
+
+	START_TIME=$SECONDS
+	START_DATE=$(date '+%x_%H:%M:%S:%N')
+	$GRUNT test:ci_parallel_main_server & pid1=$!
+	$GRUNT test:ci_parallel_same_tunnel & pid2=$!
+	wait $pid1
+	wait $pid2
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "${TEXTCOLOR}***** Done 4: same tunnel${NORM}"
+	echo "${TEXTCOLOR}$(($ELAPSED_TIME/60)) min $(($ELAPSED_TIME%60)) sec ${NORM}"
+	printCompleteCommand $START_DATE $ELAPSED_TIME
+}
+
+function same_server_seperate_tunnel {
+	# two processes on same server and separate tunnel
+	startTwoTunnels
+
+	START_TIME=$SECONDS
+	START_DATE=$(date '+%x_%H:%M:%S:%N')
+	$GRUNT test:ci_parallel_main_server & pid1=$!
+	$GRUNT test:ci_parallel_same_server & pid2=$!
+	wait $pid1
+	wait $pid2
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "${TEXTCOLOR}***** Done 5: same server${NORM}"
+	echo "${TEXTCOLOR}$(($ELAPSED_TIME/60)) min $(($ELAPSED_TIME%60)) sec ${NORM}"
+	printCompleteCommand $START_DATE $ELAPSED_TIME
+}
+
+#to run locally define export LOCAL_MODE=1 (change path to sc if needed)
+if [[ $LOCAL_MODE = 1 ]]; then
+	# SC_EXE="/Applications/sc-4.3.8-osx/bin/sc"
+    GRUNT="grunt"
+    CONNECT_URL="https://saucelabs.com/downloads/sc-4.3.10-osx.zip"
+    CONNECT_DOWNLOAD="sc-4.3.10-osx"
+    CONNECT_DOWNLOAD_FILE=$CONNECT_DOWNLOAD.zip
+fi
+
+mkdir -p $CONNECT_DIR
+
+cd $CONNECT_DIR
+
+echo "Downloading Sauce Connect..."
+if [[ ! -f ./$CONNECT_DOWNLOAD ]]; then
+   curl $CONNECT_URL > $CONNECT_DOWNLOAD_FILE 2> /dev/null
+fi
+tar -zxvf $CONNECT_DOWNLOAD_FILE
+cp $CONNECT_DOWNLOAD/bin/sc ./sc
+rm -rf $CONNECT_DOWNLOAD
+rm -f sauce-connect-ready
+
+TYPE=$((RANDOM%2));
+echo "type is ${TYPE}"
+if [[ $TYPE = 1 ]]; then
+	echo echo "${TEXTCOLOR}Running regular_mode${NORM}"
+	BUILD_MODE="regular_mode"
+	regular_mode
+else
+	echo echo "${TEXTCOLOR}Running seperate_server_and_tunnel${NORM}"
+	BUILD_MODE="seperate_server_and_tunnel"
+	seperate_server_and_tunnel
+fi

--- a/scripts/parallel_ci_osx.sh
+++ b/scripts/parallel_ci_osx.sh
@@ -1,0 +1,8 @@
+export LOCAL_MODE=1
+
+node_modules/wix-gruntfile/scripts/parallel_ci.sh
+
+killall sc
+sleep 15
+
+export LOCAL_MODE=0


### PR DESCRIPTION
Allow running two parallel test:ci processes
Also, allow running test:ci on osx provided that you have the env variables defined:
SAUCE_BROWSERS
SAUCE_USERNAME
SAUCE_ACCESS_KEY

usage: from project root directory use:
OSX - node_modules/wix-gruntfile/scripts/parallel_ci_osx.sh
Unix - node_modules/wix-gruntfile/scripts/parallel_ci.sh 