### PR TITLE
feat(*): #NGG-29| Make e2e tests generate coverage report

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@ module.exports = function (grunt, options) {
 
   var packageJson = grunt.file.readJSON('package.json');
 
+  grunt.loadNpmTasks(getRelativePluginPath('remap-istanbul'));
   grunt.loadNpmTasks(getRelativePluginPath('grunt-sass'));
 
   if (!packageJson.scripts || !packageJson.scripts.build || !packageJson.scripts.release || !packageJson.scripts.test) {
@@ -160,7 +161,8 @@ module.exports = function (grunt, options) {
 
     karma:                  require('./grunt-sections/test-runners')(grunt, options).karma,
     protractor:             require('./grunt-sections/test-runners')(grunt, options).protractor,
-    concat:                 require('./grunt-sections/export-dts')(grunt, options).concat
+    concat:                 require('./grunt-sections/export-dts')(grunt, options).concat,
+    remapIstanbul:          require('./grunt-sections/remap')(grunt, options).remapIstanbul
   });
 
   grunt.registerTask('wix-install', function () {
@@ -249,7 +251,8 @@ module.exports = function (grunt, options) {
 
   grunt.registerTask('test', [
     'pre-build:clean',
-    'karma:single'
+    'karma:single',
+    'remapIstanbul'
   ]);
 
   grunt.registerTask('test:e2e', function (type) {

--- a/grunt-sections/remap.js
+++ b/grunt-sections/remap.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function (grunt, options) {
+  return {
+    remapIstanbul: {
+      build: {
+        src: './coverage/coverage-final.json',
+        options: {
+          reports: {
+            'html': './coverage/report'
+          },
+          fail: false
+        }
+      }
+    }
+  };
+};

--- a/grunt-sections/transform-js.js
+++ b/grunt-sections/transform-js.js
@@ -92,7 +92,8 @@ module.exports = function (grunt, options) {
     typescript: {
       options: {
         target: 'es5',
-        sourceMap: false,
+        sourceRoot: process.cwd(),
+        sourceMap: true,
         declaration: createDeclaration,
         removeComments: false,
         experimentalDecorators: true,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -103,6 +103,10 @@ module.exports = function (config) {
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: true
+    singleRun: true,
+    coverageReporter: {
+         type: 'json',
+         subdir : '.'
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "protractor": "2.1.0",
     "proxy-middleware": "^0.11.0",
     "q": "^1.4.1",
+    "remap-istanbul": "^0.5.1",
     "semver": "^4.3.6",
     "shelljs": "^0.3.0",
     "terminate": "^1.0.6",


### PR DESCRIPTION
Using `grunt-istanbul` to instrument scripts from `.tmp` folder. `grunt-protractor-coverage` used to instrument e2e tests for coverage aggregation and writing result to `coverage` directory, run with `grunt test:e2ecoverage` after `grunt serve` for results.
Prints to console and creates an html inside `coverage/report` with coverage details.