### PR TITLE
add local.wix.com to the grunt-build.sh

### DIFF
--- a/scripts/grunt-build.sh
+++ b/scripts/grunt-build.sh
@@ -19,7 +19,7 @@ $SAUCE_TUNNEL \
   --user $SAUCE_USERNAME \
   --api-key $SAUCE_ACCESS_KEY \
   --logfile /tmp/sc.log \
-  --tunnel-domains localhost \
+  --tunnel-domains localhost,local.wix.com \
   --pidfile /tmp/sc.pid &
 
 while [ ! -f /tmp/sauce-connect-ready ]; do


### PR DESCRIPTION
This is the first step that we need so local.wix.com will point to localhost on SauceLabs.
The next step is to add a build step to the CI that will add local.wix.com to the hosts of the docker.