### PR TITLE
Part1: Using jasmine2 in protractor tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-coverage": "^0.3.1",
     "karma-growl-reporter": "^0.1.1",
     "karma-jasmine": "~0.1.3",
+    "karma-jasmine1-shim": "git://github.com/donataswix/karma-jasmine1-shim.git",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-osx-reporter": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-velocity-debug": "^0.1.0",
     "grunt-webfont": "^0.4.8",
     "jasmine-reporters": "^1.0.1",
-    "jasmine-reporters2": "git@github.com:mastertheblaster/jasmine-reporters.git",
+    "jasmine-reporters2": "git://github.com/mastertheblaster/jasmine-reporters.git",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "grunt-velocity-debug": "^0.1.0",
     "grunt-webfont": "^0.4.8",
     "jasmine-reporters": "^1.0.1",
+    "jasmine-reporters2": "git@github.com:mastertheblaster/jasmine-reporters.git",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.0",

--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -41,15 +41,19 @@ function hasFocusedTests(patterns, stringsRegex) {
   });
 }
 
-if(hasFocusedTests(config.specs, /^\s*\b(iit|fit|ddescribe|fdescribe)\s*\(/gm)) {
-  config.capabilities.shardTestFiles = false;
-  console.log('\x1b[33m%s\x1b[0m', 'Protractor sharding is disabled due to presence of focused tests.');
+function warn(message) {
+  console.log('\x1b[33m%s\x1b[0m', message);
 }
 
-var useJasmine2 = !!process.env.USE_JASMINE2;
+if(hasFocusedTests(config.specs, /^\s*\b(iit|fit|ddescribe|fdescribe)\s*\(/gm)) {
+  config.capabilities.shardTestFiles = false;
+  warn('Protractor sharding is disabled due to presence of focused tests.');
+}
+
+var useJasmine2 = config.framework === 'jasmine' && !!process.env.USE_JASMINE2;
 if (useJasmine2) {
   config.framework = 'jasmine2';
-  console.log('\x1b[33m%s\x1b[0m', 'Forcing protractor to use jasmine2');
+  warn('Forcing protractor to use jasmine2 testing framework.');
 }
 
 var onPrepare = config.onPrepare || function () {};

--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -46,8 +46,19 @@ if(hasFocusedTests(config.specs, /^\s*\b(iit|fit|ddescribe|fdescribe)\s*\(/gm)) 
   console.log('\x1b[33m%s\x1b[0m', 'Protractor sharding is disabled due to presence of focused tests.');
 }
 
+var useJasmine2 = !!process.env.USE_JASMINE2;
+if (useJasmine2) {
+  config.framework = 'jasmine2';
+  console.log('\x1b[33m%s\x1b[0m', 'Forcing protractor to use jasmine2');
+}
+
 var onPrepare = config.onPrepare || function () {};
 config.onPrepare = function () {
+
+  if (useJasmine2) {
+    require('karma-jasmine1-shim/lib/shim');
+  }
+
   // Disable animations so e2e tests run more quickly
   var disableNgAnimate = function () {
     angular.module('disableNgAnimate', []).run(function ($animate) {

--- a/protractor-teamcity-conf.js
+++ b/protractor-teamcity-conf.js
@@ -16,7 +16,10 @@ if (process.env.BUILD_NUMBER !== '12345') {
     // config.capabilities.shardTestFiles = false;
   }
   config.onPrepare = function () {
-    if (config.framework !== 'jasmine2') {
+    if (config.framework === 'jasmine2') {
+      var reporters = require('jasmine-reporters2');
+      jasmine.getEnv().addReporter(new reporters.TeamcityReporter());
+    } else {
       require('jasmine-reporters');
       jasmine.getEnv().addReporter(new jasmine.TeamcityReporter());
     }

--- a/protractor-teamcity-conf.js
+++ b/protractor-teamcity-conf.js
@@ -16,8 +16,10 @@ if (process.env.BUILD_NUMBER !== '12345') {
     // config.capabilities.shardTestFiles = false;
   }
   config.onPrepare = function () {
-    require('jasmine-reporters');
-    jasmine.getEnv().addReporter(new jasmine.TeamcityReporter());
+    if (config.framework !== 'jasmine2') {
+      require('jasmine-reporters');
+      jasmine.getEnv().addReporter(new jasmine.TeamcityReporter());
+    }
     onPrepare.apply(this, arguments);
   };
 }


### PR DESCRIPTION
This is a first part for forcing using the jasmine2 in protractor depending on environment variable.

Example usage is:
```bash
export USE_JASMINE2=true
protractor protractor-conf.js
grunt build
```
In order to allow multiple versions of jasmine-reporters i have forked a project and temporary renamed the package name. Once we completely move to jasmine2 we will get rid of that fork.

Here is the example output of the e2e tests run with jasmine2 and shim.
<img width="1340" src="https://cloud.githubusercontent.com/assets/10008149/9540064/e077769a-4d62-11e5-86d5-08d7ac47f188.png">
