### PR TITLE
Part2: Using jasmine2 in karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,9 +8,23 @@ module.exports = function (config) {
   var os = require('os');
   var isOsx = os.platform()  === 'darwin';
 
-  config.set({
-    plugins: [
-      'karma-jasmine',
+  var frameworks = ['jasmine'],
+      plugins = [
+        'karma-jasmine',
+        'karma-coverage',
+        'karma-phantomjs-launcher',
+        'karma-growl-reporter',
+        'karma-osx-reporter',
+        'karma-teamcity-reporter',
+        'karma-ng-html2js-preprocessor',
+        'karma-chrome-launcher',
+        'karma-simple-reporter'];
+
+  if (!!process.env.USE_JASMINE2) {
+    frameworks = ['jasmine2', 'jasmine1-shim'];
+    plugins = [
+      'karma-jasmine2',
+      'karma-jasmine1-shim',
       'karma-coverage',
       'karma-phantomjs-launcher',
       'karma-growl-reporter',
@@ -18,8 +32,11 @@ module.exports = function (config) {
       'karma-teamcity-reporter',
       'karma-ng-html2js-preprocessor',
       'karma-chrome-launcher',
-      'karma-simple-reporter'
-    ],
+      'karma-simple-reporter'];
+  }
+
+  config.set({
+    plugins: plugins,
 
     preprocessors: {
       '{app,.tmp}/scripts/{,!(lib)/**/}*.js': 'coverage',
@@ -32,7 +49,7 @@ module.exports = function (config) {
     basePath: '',
 
     // testing framework to use (jasmine/mocha/qunit/...)
-    frameworks: ['jasmine'],
+    frameworks: frameworks,
 
     // list of files / patterns to load in the browser
     files: [ ],

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "grunt-webfont": "^0.4.8",
     "jasmine-reporters": "^1.0.1",
     "jasmine-reporters2": "git://github.com/mastertheblaster/jasmine-reporters.git",
+    "jasmine-core": "^2.3.0",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "karma-coverage": "^0.3.1",
     "karma-growl-reporter": "^0.1.1",
     "karma-jasmine": "~0.1.3",
+    "karam-jasmine2": "git://github.com/mastertheblaster/karma-jasmine.git",
     "karma-jasmine1-shim": "git://github.com/donataswix/karma-jasmine1-shim.git",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-osx-reporter": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "karma-coverage": "^0.3.1",
     "karma-growl-reporter": "^0.1.1",
     "karma-jasmine": "~0.1.3",
-    "karam-jasmine2": "git://github.com/mastertheblaster/karma-jasmine.git",
+    "karma-jasmine2": "git://github.com/mastertheblaster/karma-jasmine.git",
     "karma-jasmine1-shim": "git://github.com/donataswix/karma-jasmine1-shim.git",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-osx-reporter": "^0.2.0",


### PR DESCRIPTION
Very simple:

```shell
export USE_JASMINE2=true
grunt serve
```

Currently both version jasmine 1.3... and jasmine 2... are completely supported.

This is an example of running `grunt serve:clean` without environment variable:
![screen shot 2015-08-28 at 11 20 56](https://cloud.githubusercontent.com/assets/10008149/9544618/fc654d50-4d8a-11e5-8971-a46b51ecdbda.png)

And this one forces jasmine2:
![screen shot 2015-08-28 at 13 44 37](https://cloud.githubusercontent.com/assets/10008149/9544624/0330fac6-4d8b-11e5-83dc-8418951682e9.png)