### PR TITLE
Option for disabling the karma (tests) using just a flag --nokarma

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -318,9 +318,11 @@ module.exports = function (grunt, options) {
     }
     grunt.config(what, conf);
   };
-  
+
   if (options.enableAngularMigration) {
     require('./grunt-sections/angular-migration')(grunt, options).addMigration();
   }
+
+  require('./grunt-sections/flag-nokarma')(grunt, options);
 
 };

--- a/grunt-sections/flag-nokarma.js
+++ b/grunt-sections/flag-nokarma.js
@@ -1,0 +1,16 @@
+/* global process */
+'use strict';
+
+module.exports = function (grunt) {
+
+  var noKarma = (process.argv.indexOf('--nokarma') !== -1);
+  if (noKarma) {
+    grunt.registerTask('noKarma', function () {
+      grunt.log.writeln('WITH GREAT POWER COMES GREAT RESPONSIBILITY!');
+    });
+    var deps = grunt.hookTask('karma');
+    deps.splice(0, 1);
+    deps.push('noKarma');
+  }
+
+}


### PR DESCRIPTION
Example output with a flag:

<img width="379" alt="screen shot 2015-09-03 at 14 47 53" src="https://cloud.githubusercontent.com/assets/10008149/9657579/06c32bf4-524b-11e5-84e3-460b1434c3c0.png">

@justame Please take a look if this is what you wanted.

```shell
# Dangerous code goes below. Use with precaution!
grunt serve:clean --nokarma
```

Actually the same stuff could be accomplished by temporary renaming on test from `it` to `iit`.