### PR TITLE
Fixed issue with tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "shelljs": "^0.3.0",
     "time-grunt": "^1.0.0",
     "tiny-lr": "^0.1.6",
-    "tslint": "^2.5.0-beta",
+    "tslint": "2.5.0-beta",
     "typescript": "^1.5.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-text-replace": "^0.4.0",
     "grunt-traceur-latest": "~0.0.4",
     "grunt-ts": "^4.0.0",
-    "grunt-tslint": "^2.3.1-beta",
+    "grunt-tslint": "^2.5.0-beta",
     "grunt-usemin": "^2.6.2",
     "grunt-velocity-debug": "^0.1.0",
     "grunt-webfont": "^0.4.8",
@@ -78,7 +78,7 @@
     "shelljs": "^0.3.0",
     "time-grunt": "^1.0.0",
     "tiny-lr": "^0.1.6",
-    "tslint": "^2.3.1-beta",
+    "tslint": "^2.5.0-beta",
     "typescript": "^1.5.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Recently there was an update for `grunt-tslint`.
It started requiring `tslint 2.5.0-beta` version.
However the "tslint": "^2.3.1-beta" doesn't resolved to 2.5.0-beta.
It resolved to 2.4.5 instead.