### PR TITLE
Fix get relative plugin path on windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,7 +101,7 @@ module.exports = function (grunt, options) {
   }
 
   function getRelativePluginPath(name) {
-    var pluginPath = require.resolve(name + '/package.json').replace('/package.json', '');
+    var pluginPath = require.resolve(name + '/package.json').replace(path.sep + 'package.json', '');
     var relativePath = path.relative(process.cwd() + '/node_modules', pluginPath);
     return relativePath;
   }


### PR DESCRIPTION
`getRelativePluginPath` after resolve do not uses OS specific path separator. So on windows it cannot load tasks. It tries to get task from `wix-gruntfile\node_modules\grunt-wix-inline\package.json\tasks`