### PR TITLE
we can't use fast-compile because we use tsconfig

### DIFF
--- a/grunt-sections/transform-js.js
+++ b/grunt-sections/transform-js.js
@@ -96,7 +96,8 @@ module.exports = function (grunt, options) {
         declaration: createDeclaration,
         removeComments: false,
         experimentalDecorators: true,
-        module: 'commonjs'
+        module: 'commonjs',
+        fast: 'never'
       },
       build: typeScriptConfig
     }


### PR DESCRIPTION
We can't use fast-compile because we use tsconfig with 'files', once we move to es6 modules fast-compile is a good thing.