### PR TITLE
add assembly plugin descriptor for vms only

### DIFF
--- a/vms.tar.gz.xml
+++ b/vms.tar.gz.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>wix-angular</id>
+    <baseDirectory>/</baseDirectory>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/dist</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*.vm</include>
+                <include>*/**/*.vm</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
Adding a new maven assembly plugin descriptor to include only .vm files.
This descriptor will be used in the generator-wix-angular project pom.xml