### PR TITLE
#NGG-125|publish bower components to npm as well

### DIFF
--- a/grunt-helpers/grunt-overrides.js
+++ b/grunt-helpers/grunt-overrides.js
@@ -1,8 +1,8 @@
 'use strict';
 
-module.exports = function (grunt) {
+module.exports = function (grunt, options) {
 
-  function verifyNpmScripts(grunt) {
+  function verifyNpmScripts(grunt, options) {
     var packageJson = grunt.file.readJSON('package.json');
 
     if (!packageJson.scripts || !packageJson.scripts.build || !packageJson.scripts.release || !packageJson.scripts.test) {
@@ -11,6 +11,13 @@ module.exports = function (grunt) {
       packageJson.scripts.release = packageJson.scripts.release || 'node_modules/wix-gruntfile/scripts/release.sh';
       packageJson.scripts.test = packageJson.scripts.test || '#tbd';
       packageJson.scripts.start = packageJson.scripts.start || 'grunt serve';
+      grunt.file.write('package.json', JSON.stringify(packageJson, null, 2));
+    }
+
+    if (options.bowerComponent && packageJson.private && !packageJson.publishConfig) {
+      console.log('Change things');
+      packageJson.private = false;
+      packageJson.publishConfig = { registry: 'http://repo.dev.wix/artifactory/api/npm/npm-local/' };
       grunt.file.write('package.json', JSON.stringify(packageJson, null, 2));
     }
 
@@ -38,6 +45,6 @@ module.exports = function (grunt) {
     }
   }
 
-  verifyNpmScripts(grunt);
+  verifyNpmScripts(grunt, options);
   verifyVmsArtifactConfiguration(grunt);
 };

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "wix-cdn-data": "^0.1.0",
     "grunt-petri-experiments": "^1.0.0",
     "grunt-extract-styles": "^1.1.0",
-    "grunt-wix-inline": "^0.3.3"
+    "grunt-wix-inline": "^0.3.3",
+    "wnpm-ci": "^6.1.0"
   },
   "peerDependencies": {
     "bower": "^1.3.1",
@@ -113,8 +114,5 @@
   "scripts": {
     "build": ":",
     "release": "wnpm-release --no-shrinkwrap"
-  },
-  "devDependencies": {
-    "wnpm-ci": "^6.0.60"
   }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,6 +24,10 @@ git add --all .
 git reset HEAD bower.json
 git diff --exit-code --cached --stat
 
+if type "wnpm-release" &> /dev/null; then
+    wnpm-release --no-shrinkwrap
+fi
+
 if [ $? -ne 0 ]; then
     $(npm bin)/grunt publish
 fi


### PR DESCRIPTION
Change bower components with `private: true` to `private: false` & assign our local npm, then publish it via `wnpm`.