### PR TITLE
make wix-gruntfile pom.xml the parent of all repos running grunt

### DIFF
--- a/grunt-helpers/data/new-parent-artifact.xml
+++ b/grunt-helpers/data/new-parent-artifact.xml
@@ -1,0 +1,6 @@
+
+    <parent>
+      <groupId>com.wixpress</groupId>
+      <artifactId>wix-gruntfile</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </parent>

--- a/grunt-helpers/data/new-plugin-settings.xml
+++ b/grunt-helpers/data/new-plugin-settings.xml
@@ -1,0 +1,5 @@
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>

--- a/grunt-helpers/grunt-overrides-npm.js
+++ b/grunt-helpers/grunt-overrides-npm.js
@@ -26,24 +26,6 @@ module.exports = function (grunt, options) {
     }
   }
 
-  function verifyVmsArtifactConfiguration() {
-    var pomXml = grunt.file.read('pom.xml');
-    var vmsArtifactXml = grunt.file.read('node_modules/wix-gruntfile/grunt-helpers/data/vms-artifact-plugin.xml');
-
-    if (pomXml.indexOf('node_modules/wix-gruntfile/vms.tar.gz.xml') !== -1) {
-      var posixNewLine = pomXml.indexOf('\r\n') === -1;
-      pomXml = pomXml.split(/\r?\n/g).join('\n');
-      grunt.log.writeln('=== UNPATCHING YOUR POM.XML ===');
-
-      var modifiedPomXml = pomXml.replace(vmsArtifactXml, '');
-      if (modifiedPomXml.indexOf('node_modules/wix-gruntfile/vms.tar.gz.xml') !== -1) {
-        grunt.log.writeln('=== FAILED UNPATCHING!!! ===');
-      } else {
-        grunt.file.write('pom.xml', modifiedPomXml.split('\n').join(posixNewLine ? '\n' : '\r\n'));
-      }
-    }
-  }
-
   function fixTslintJson() {
     if (grunt.file.exists('tslint.json')) {
       let tslint = grunt.file.readJSON('tslint.json');
@@ -57,5 +39,4 @@ module.exports = function (grunt, options) {
 
   fixTslintJson();
   verifyNpmScripts();
-  verifyVmsArtifactConfiguration();
 };

--- a/grunt-helpers/grunt-overrides-pom.js
+++ b/grunt-helpers/grunt-overrides-pom.js
@@ -1,0 +1,99 @@
+'use strict';
+
+module.exports = function (grunt, options) {
+
+  function isPosix(xmlString) {
+    return xmlString.indexOf('\r\n') === -1;
+  }
+
+  function verifyVmsArtifactConfiguration(grunt) {
+    var pomXml = grunt.file.read('pom.xml');
+    var vmsArtifactXml = grunt.file.read('node_modules/wix-gruntfile/grunt-helpers/data/vms-artifact-plugin.xml');
+
+    if (pomXml.indexOf('node_modules/wix-gruntfile/vms.tar.gz.xml') !== -1) {
+      var posixNewLine = pomXml.indexOf('\r\n') === -1;
+      pomXml = pomXml.split(/\r?\n/g).join('\n');
+      grunt.log.writeln('=== UNPATCHING YOUR POM.XML ===');
+
+      var modifiedPomXml = pomXml.replace(vmsArtifactXml, '');
+      if (modifiedPomXml.indexOf('node_modules/wix-gruntfile/vms.tar.gz.xml') !== -1) {
+        grunt.log.writeln('=== FAILED UNPATCHING!!! ===');
+      } else {
+        grunt.file.write('pom.xml', modifiedPomXml.split('\n').join(posixNewLine ? '\n' : '\r\n'));
+      }
+    }
+  }
+
+
+  function isOldParent(xmlString) {
+    var parentArtifact = '<artifactId>wix-master-parent</artifactId>';
+    var parentGroup = '<groupId>com.wixpress.common</groupId>';
+
+    return xmlString.indexOf(parentArtifact) !== -1 &&
+      xmlString.indexOf(parentGroup) !== -1;
+  }
+
+  function replaceXml(xmlString, start, end, replaceFile) {
+    var replaceXml = grunt.file.read(replaceFile);
+    xmlString = xmlString.split(/\r?\n/g).join('\n');
+    return xmlString.substr(0, start).trim() + replaceXml + xmlString.substr(end);
+  }
+
+  function writePomXml(xmlString) {
+    grunt.file.write('pom.xml', xmlString.split('\n').join(isPosix(xmlString) ? '\n' : '\r\n'));
+  }
+
+
+  function updateParent(grunt) {
+    var pomXml = grunt.file.read('pom.xml');
+    var parentStart = pomXml.indexOf('<parent>');
+    var parentEnd = pomXml.indexOf('</parent>', parentStart);
+
+    if (!isOldParent(pomXml) || parentStart === -1 || parentEnd === -1) {
+      return false;
+    }
+
+    grunt.log.writeln('=== UPGRADING YOUR POM.XML TO USE NEW PARENT ===');
+
+    writePomXml(replaceXml(pomXml,
+      parentStart,
+      parentEnd+9,
+      'node_modules/wix-gruntfile/grunt-helpers/data/new-parent-artifact.xml'));
+    return true;
+  }
+
+  function updatePluginSettings(grunt) {
+    var pomXml = grunt.file.read('pom.xml');
+    var descriptorIdx = pomXml.indexOf('<descriptor>node_modules/wix-gruntfile/tar.gz.xml</descriptor>');
+    if (descriptorIdx === -1) {
+      grunt.log.writeln('could not find "<descriptor>node_modules/wix-gruntfile/tar.gz.xml</descriptor>"');
+      return false;
+    }
+
+    var pluginStart = pomXml.indexOf('<plugin>', descriptorIdx-500);
+    var pluginEnd = pomXml.indexOf('</plugin>', pluginStart);
+    if (pluginStart === -1 || pluginEnd === -1) {
+      grunt.log.writeln('could not find <plugin></plugin> boundaries', pluginStart, pluginEnd);
+      return false;
+    }
+
+    grunt.log.writeln('=== UPGRADING YOUR POM.XML TO USE NEW PLUGIN SETTINGS ===');
+
+    writePomXml(replaceXml(pomXml,
+      pluginStart,
+      pluginEnd+9,
+      'node_modules/wix-gruntfile/grunt-helpers/data/new-plugin-settings.xml'));
+    return true;
+  }
+
+  function verifyPomUpgrade(grunt) {
+    if (!updateParent(grunt)) {
+      return false;
+    }
+
+    return updatePluginSettings(grunt);
+  }
+
+  verifyVmsArtifactConfiguration(grunt);
+  verifyPomUpgrade(grunt)
+};

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
               <configuration>
                 <descriptor>node_modules/wix-gruntfile/vm-only.tar.gz.xml</descriptor>
                 <appendAssemblyId>true</appendAssemblyId>
-                <finalName>${project.artifactId}-vms-${project.version}</finalName>
+                <finalName>${project.artifactId}-${project.version}</finalName>
               </configuration>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,26 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.wixpress</groupId>
-    <artifactId>wix-gruntfile</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>wix-gruntfile</name>
-    <description>wix-gruntfile</description>
-    <packaging>pom</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.wixpress</groupId>
+  <artifactId>wix-gruntfile</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>wix-gruntfile</name>
+  <description>wix-gruntfile</description>
+  <packaging>pom</packaging>
 
-    <parent>
-        <groupId>com.wixpress.common</groupId>
-        <artifactId>wix-master-parent</artifactId>
-        <version>100.0.0-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <groupId>com.wixpress.common</groupId>
+    <artifactId>wix-master-parent</artifactId>
+    <version>100.0.0-SNAPSHOT</version>
+  </parent>
 
-    <developers>
-        <developer>
-            <name>Shahar Talmi</name>
-            <email>shahart@wix.com</email>
-            <roles>
-                <role>owner</role>
-            </roles>
-        </developer>
-    </developers>
+  <developers>
+    <developer>
+      <name>Shahar Talmi</name>
+      <email>shahart@wix.com</email>
+      <roles>
+        <role>owner</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.2.1</version>
+          <executions>
+            <execution>
+              <id>full-artifact</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <configuration>
+                <descriptor>node_modules/wix-gruntfile/tar.gz.xml</descriptor>
+                <appendAssemblyId>false</appendAssemblyId>
+                <finalName>${project.artifactId}-${project.version}</finalName>
+              </configuration>
+            </execution>
+            <execution>
+              <id>vms-artifact</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <configuration>
+                <descriptor>node_modules/wix-gruntfile/vm-only.tar.gz.xml</descriptor>
+                <appendAssemblyId>true</appendAssemblyId>
+                <finalName>${project.artifactId}-vms-${project.version}</finalName>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -1,4 +1,4 @@
-/* global browser, angular, document, beforeEach, afterEach */
+/* global browser, angular, document, beforeEach, afterEach, jasmine */
 'use strict';
 
 var fs = require('fs');
@@ -57,10 +57,8 @@ config.onPrepare = function () {
   require('babel/register');
   console.log('onPrepare!!!');
 
-  if (process.env.SCREEN_SHOT_REPORTER) {
-    var ScreenshotReporter = require('screenshot-reporter');
-    jasmine.getEnv().addReporter(new ScreenshotReporter());
-  }
+  var ScreenshotReporter = require('screenshot-reporter');
+  jasmine.getEnv().addReporter(new ScreenshotReporter());
 
   // Disable animations so e2e tests run more quickly
   var disableNgAnimate = function () {

--- a/vm-only.tar.gz.xml
+++ b/vm-only.tar.gz.xml
@@ -1,0 +1,20 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>wix-angular</id>
+    <baseDirectory>/</baseDirectory>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/dist</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>.sadignore</include>
+                <include>*.vm</include>
+                <include>*/**/*.vm</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/wix-gruntfile.js
+++ b/wix-gruntfile.js
@@ -2,7 +2,8 @@
 
 module.exports = function (grunt, options) {
   options = require('./grunt-helpers/grunt-options')(grunt, options);
-  require('./grunt-helpers/grunt-overrides')(grunt, options);
+  require('./grunt-helpers/grunt-overrides-npm')(grunt, options);
+  require('./grunt-helpers/grunt-overrides-pom')(grunt, options);
   require('./grunt-helpers/grunt-load')(grunt, options);
   require('./grunt-helpers/grunt-init-config')(grunt, options);
   require('./grunt-helpers/grunt-extensions.js')(grunt, options);


### PR DESCRIPTION
1. Modified pom.xml to contain all needed tar files.
2. When running grunt for the first the time the project's pom changes its parent to point to wix-gruntfile's pom.
3. If a known plugin is set on the project's pom, it is replaced to point to the same plugin on the parent.