### PR TITLE
fix(appFirst): reflect to the new order

### DIFF
--- a/grunt-sections/test-runners.js
+++ b/grunt-sections/test-runners.js
@@ -7,14 +7,14 @@ module.exports = function (grunt, options) {
   var unitTestWildCards = [
     {pattern: 'app/images/**/*.*', watched: false, included: false, served: true},
     '{app,.tmp}/*.js',
-    '{app,.tmp}/{scripts,modules}/*.js', //do not move - position 1
-    '{app,.tmp}/{scripts,modules}/*/**/*.js', //do not move - position 2
+    '{app,.tmp}/{scripts,modules}/*.js', //do not move - position 2
+    '{app,.tmp}/{scripts,modules}/*/**/*.js', //do not move - position 3
     '{,app/,.tmp/}test/**/*.js',
     '{app,.tmp}/{views,modules}/**/*.html'
   ];
 
   if (!options.appFirst) {
-    unitTestWildCards.replace(1, 2);
+    unitTestWildCards.replace(2, 3);
   }
 
   options.karmaConf.files = options.karmaTestFiles || options.karmaConf.files.concat(unitTestWildCards);


### PR DESCRIPTION
Due to [this](https://github.com/wix/wix-gruntfile/commit/52a2552b75a06f7976cd49c0ee0e6669aa93ff63#diff-01288e40ddc7d1c18736148d50e99bf3R8) commit.

Btw, I would consider a convention to load modules' declarations before the other parts of the module. If a service of module `x` is included in html before it's module declared, it's a problem...

For instance, the glob `{app,.tmp}/{scripts,modules}/*/**/*.js` will make this output:
```html
<script src="base/modules/module/module.cmp.js" />
<script src="base/modules/module/module.mdl.js" />
```
