### PR TITLE
Added cross-spawn package to fix spawn issue on windows

### DIFF
--- a/grunt-protractor.js
+++ b/grunt-protractor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var terminate = require('terminate');
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 var grunt = require('grunt');
 var protractorDir = require.resolve('protractor/bin/elementexplorer.js').replace('elementexplorer.js', '');
 

--- a/grunt-sections/verify-npm.js
+++ b/grunt-sections/verify-npm.js
@@ -58,7 +58,8 @@ module.exports = function register(grunt) {
       }
 
       function execNpmVerify() {
-        let cmd = require('child_process').spawn('npm', OUTDATED_CMD_TOKENS, {detached: true});
+        let spawn = require('cross-spawn');
+        let cmd = spawn('npm', OUTDATED_CMD_TOKENS, {detached: true});
         let result = '';
         cmd.stdout.on('data', (output) => {
           result += output;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chalk": "^1.1.1",
     "compression": "^1.2.0",
     "connect-injector": "^0.4.2",
+    "cross-spawn": "^5.0.1",
     "glob": "^5.0.3",
     "grunt": "^0.4.5",
     "grunt-angular-templates": "^0.5.1",

--- a/server-runner.js
+++ b/server-runner.js
@@ -1,7 +1,7 @@
 /* global afterEach, browser */
 'use strict';
 
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 var q = require('q');
 var serverProcess;
 


### PR DESCRIPTION
The standard nodejs API for 'spawn' has issues on windows. More info on that can be found here:
[https://github.com/nodejs/node-v0.x-archive/issues/2318](https://github.com/nodejs/node-v0.x-archive/issues/2318), this issue has been open for about 6 years.

While there have been many suggestions in the nodejs issue thread, I found the most reliable to be adding the npm package of [https://www.npmjs.com/package/cross-spawn](https://www.npmjs.com/package/cross-spawn). You can see in the npm page of the package the author describes why using cross-spawn is better than adding shell: true parameter (this has been around since node v6).