### PR TITLE
Soft replacement of filesGlob hack with a native "include" option of TS 2.0+

### DIFF
--- a/grunt-sections/transform-js.js
+++ b/grunt-sections/transform-js.js
@@ -57,10 +57,17 @@ module.exports = function (grunt, options) {
 
   var typeScriptConfig;
   if (featureDetector.isTSConfigEnabled()) {
+    var tsConfigJsonPath = 'app/tsconfig.json';
+    var tsConfigJson = grunt.file.readJSON(tsConfigJsonPath);
+    var isUsingTS20Include = !tsConfigJson.filesGlob && !!tsConfigJson.include;
+
     typeScriptConfig = {
       outDir: '.tmp',
-      tsconfig: {
-        tsconfig: 'app/tsconfig.json',
+      tsconfig: isUsingTS20Include ? {
+        tsconfig: 'app/',
+        passThrough: true
+      } : {
+        tsconfig: tsConfigJsonPath,
         ignoreFiles: true,
         ignoreSettings: false,
         overwriteFilesGlob: false,


### PR DESCRIPTION
As the `filesGlob` property provided by [grunt-ts](https://github.com/TypeStrong/grunt-ts) was a temporary solution and TypeScript since 2.0 is providing a built-in functionality for expanding glob file patterns in its new properties `include` and `exclude`, I decided to make this pull request.

In this change we'll start detecting the usage of `include` property (and absence of `filesGlob` property) in `tsconfig.json`.

In the positive case, we simply give the control to `tsc` compiler which knows how to do its job and doesn't require workarounds from the side of `grunt-ts` anymore. Tested on local `grunt` builds for Wix SM (1000+ files).

In the negative case, we continue to provide a backward-compatible configuration to make sure we don't break anything in existing projects.