### PR TITLE
fixed protractor stdin

### DIFF
--- a/grunt-protractor.js
+++ b/grunt-protractor.js
@@ -56,6 +56,7 @@ module.exports = {
     scheduleRetry();
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
+    process.stdin.pipe(p.stdin);
     p.stdout.on('data', function (data) {
       if (data.indexOf('beforeLaunch: start') > -1) {
         clearTimeout(retry);


### PR DESCRIPTION
Right now it's not possible to debug protractor tests, if I have a 'browser.pause()' line in my tests, protractor enters debug mode but it seems like it "freezes", and I don't really have any ways to debug except repeated console prints, and that's not fun at all.  The reason being that standard input isn't passed to the child process.  

Not sure if this was done intentionally or not, but I think this should be allowed. 