### PR TITLE
enable proxying WebSocket

### DIFF
--- a/grunt-sections/connect.js
+++ b/grunt-sections/connect.js
@@ -21,6 +21,19 @@ module.exports = function (grunt, options) {
     return proxyMiddleware(proxyOptions);
   }
 
+  function proxyFolderWithWebSocket(src, dest) {
+    var proxyWsMiddleware = require('http-proxy-middleware');
+    return proxyWsMiddleware(src, {
+      target: grunt.template.process(dest),
+      ws: true,
+      pathRewrite: function (path, req) {
+        return path.replace(src, '');
+      }
+    });
+  }
+
+  proxyFolder = options.proxyWebSocket ? proxyFolderWithWebSocket : proxyFolder;
+
   function getProxies(proxyType) {
     var arr = [];
     for (var key in options[proxyType]) {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "grunt-velocity-debug": "^0.1.0",
     "grunt-velocity-parser": "sarunas/grunt-velocity",
     "grunt-webfont": "borislit/grunt-webfont#winston-version-bump",
+    "http-proxy-middleware": "^0.17.4",
     "inquirer": "^0.11.1",
     "istanbul": "^0.4.2",
     "jasmine-core": "^2.3.0",


### PR DESCRIPTION
Hey,
Allow users to forward WebSocket requests. We use web sockets quite extensively in our app, this would make our lives a lot easier. 

