### PR TITLE
Allow configuration of fonts directory

### DIFF
--- a/grunt-sections/transform-css.js
+++ b/grunt-sections/transform-css.js
@@ -36,7 +36,7 @@ module.exports = function (grunt, options) {
         generatedImagesDir: '.tmp/images/generated',
         imagesDir: 'app/images',
         javascriptsDir: 'app/scripts',
-        fontsDir: 'app/fonts',
+        fontsDir: options.fontsDir || 'app/fonts',
         importPath: ['app/bower_components', '.tmp/styles/'],
         httpImagesPath: '../images',
         httpGeneratedImagesPath: '../images/generated',


### PR DESCRIPTION
As part of the storemanager split we need to configure the fonts to be read from the .tmp folder.