### PR TITLE
upgrade node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "karma-teamcity-reporter": "^0.1.0",
     "load-grunt-tasks": "^3.1.0",
     "lodash": "^4.3.0",
-    "node-sass-asset-functions": "0.0.9",
+    "node-sass-asset-functions": "0.1.0",
     "phantomjs-prebuilt": "^2.1.7",
     "protractor": "^3.0.0",
     "protractor-browser-logs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grunt-ng-annotate": "^1.0.0",
     "grunt-process-tags": "^1.0.2",
     "grunt-release": "^0.12.0",
-    "grunt-sass": "^1.1.0",
+    "grunt-sass": "^2.0.0",
     "grunt-scss-lint": "^0.3.3",
     "grunt-svgmin": "^2.0.0",
     "grunt-text-replace": "^0.4.0",


### PR DESCRIPTION
Current version isn't supported in node 8 out of the box so instead of downloading it, we compile it each time in ci or locally. This process adds 2 minutes to build time.
Latest version is supported and it's backward compatible so no need to migrate.

Reference: https://github.com/sass/node-sass/releases
Old build (node 6): http://tc.dev.wixpress.com/viewLog.html?buildId=55125866&buildTypeId=WixEcommerceServices_WixEcommerceStoreManager&tab=buildLog&state=73%2C87#_state=73,87&focus=163
New build (node 8): http://tc.dev.wixpress.com/viewLog.html?buildId=56090768&buildTypeId=WixEcommerceServices_WixEcommerceStoreManager&tab=buildLog#_state=77,130&focus=256 